### PR TITLE
Allow a specific timestamp using the configuration object

### DIFF
--- a/src/PhpcrAdapter.php
+++ b/src/PhpcrAdapter.php
@@ -172,14 +172,18 @@ class PhpcrAdapter extends AbstractAdapter
             }
         }
         $content->setProperty('jcr:mimeType', $mimetype);
+
+        $type = 'file';
+        $result = compact('mimetype', 'type', 'path');
+
         if ($encoding = $config->get('encoding')) {
+            $result['encoding'] = $encoding;
             $content->setProperty('jcr:encoding', $encoding);
         }
         if($timestamp = $config->get('timestamp')) {
+            $result['timestamp'] = $timestamp;
             $content->setProperty('jcr:lastModified', $timestamp);
         }
-        $type = 'file';
-        $result = compact('mimetype', 'type', 'path');
 
         return $result;
     }

--- a/src/PhpcrAdapter.php
+++ b/src/PhpcrAdapter.php
@@ -175,6 +175,9 @@ class PhpcrAdapter extends AbstractAdapter
         if ($encoding = $config->get('encoding')) {
             $content->setProperty('jcr:encoding', $encoding);
         }
+        if($timestamp = $config->get('timestamp')) {
+            $content->setProperty('jcr:lastModified', $timestamp);
+        }
         $type = 'file';
         $result = compact('mimetype', 'type', 'path');
 

--- a/tests/PhpcrAdapterTest.php
+++ b/tests/PhpcrAdapterTest.php
@@ -308,4 +308,15 @@ class PhpcrAdapterTest extends \PHPUnit_Framework_TestCase
         $this->adapter->setPathPrefix($this->root . '/');
         $this->assertEquals($this->root, $this->adapter->applyPathPrefix('/'));
     }
+
+    public function testWriteWithSpecificTimestampInConfig()
+    {
+        $timestamp = strtotime('today midnight');
+        $this->adapter->write('dummy.txt', '1234', new Config(['timestamp' => $timestamp]));
+        $result = $this->adapter->getTimestamp('dummy.txt');
+        $this->assertInternalType('array', $result);
+        $this->assertArrayHasKey('timestamp', $result);
+        $this->assertInternalType('int', $result['timestamp']);
+        $this->assertEquals($timestamp, $result['timestamp']);
+    }
 }


### PR DESCRIPTION
Useful when using PHPCR to be "in sync" with another filesystem and exactly the same timestamps should be used to determine which files might have changed in a later stage...

**Use Case**
Imagine a PHP Content Repository that is used to store uploaded files on a periodic basis, for example once an hour. 

At the time the content is saved to the PHP Content Repository, the timestamp of that moment is used. While the timestamp of upload / of the file should be used.